### PR TITLE
Chrome fix

### DIFF
--- a/sibilant.js
+++ b/sibilant.js
@@ -2,7 +2,7 @@ const microevent = require('microevent')
 const _ = require('lodash')
 
 // get audio context
-const AudioContextType = window.webkitAudioContext || window.AudioContext
+const AudioContextType = window.AudioContext || window.webkitAudioContext
 
 // f_1 band for (most) human voice range
 var LOW_FREQ_CUT = 85

--- a/sibilant.js
+++ b/sibilant.js
@@ -82,6 +82,8 @@ var Sibilant = function (element, options) {
   }
   analyser.connect(bandPassNode)
   bandPassNode.connect(speakingNode)
+  // needed for chrome onprocessaudio compatibility
+  speakingNode.connect(audioContext.destination)
 }
 
 microevent.mixin(Sibilant)


### PR DESCRIPTION
Sibilant wasn't working in chrome because there's this bug where you have to connect your last node to a destination or else onaudioprocess won't fire! :open_mouth:  [stackoverflow link](http://stackoverflow.com/questions/27324608/web-audio-onaudioprocess-works-in-firefox-jsfiddle-in-chrome-but-not-chrome-it)

Also, switched the order of `const AudioContextType = window.AudioContext || window.webkitAudioContext` to stop chrome from giving an annoying warning about the webkit prefix being deprecated.
